### PR TITLE
Feature/element children pitches

### DIFF
--- a/emscripten/buildToolkit
+++ b/emscripten/buildToolkit
@@ -170,6 +170,7 @@ $exports .= "'_vrvToolkit_getAvailableOptions',";
 $exports .= "'_vrvToolkit_getElementAttr',";
 $exports .= "'_vrvToolkit_getElementChildPitches',";
 $exports .= "'_vrvToolkit_getElementsAtTime',";
+$exports .= "'_vrvToolkit_getElementStaffDef',";
 $exports .= "'_vrvToolkit_getHumdrum',";
 $exports .= "'_vrvToolkit_getLog',";
 $exports .= "'_vrvToolkit_getMEI',";

--- a/emscripten/buildToolkit
+++ b/emscripten/buildToolkit
@@ -168,6 +168,7 @@ $exports .= "'_vrvToolkit_destructor',";
 $exports .= "'_vrvToolkit_edit',";
 $exports .= "'_vrvToolkit_getAvailableOptions',";
 $exports .= "'_vrvToolkit_getElementAttr',";
+$exports .= "'_vrvToolkit_getElementChildPitches',";
 $exports .= "'_vrvToolkit_getElementsAtTime',";
 $exports .= "'_vrvToolkit_getHumdrum',";
 $exports .= "'_vrvToolkit_getLog',";

--- a/emscripten/emscripten_main.cpp
+++ b/emscripten/emscripten_main.cpp
@@ -24,6 +24,7 @@ void vrvToolkit_destructor(Toolkit *tk);
 bool vrvToolkit_edit(Toolkit *tk, const char *editorAction);
 const char *vrvToolkit_getAvailableOptions(Toolkit *tk);
 const char *vrvToolkit_getElementAttr(Toolkit *tk, const char *xmlId);
+const char *vrvToolkit_getElementChildPitches(Toolkit *tk, const char *xmlId);
 const char *vrvToolkit_getElementsAtTime(Toolkit *tk, int millisec);
 const char *vrvToolkit_getHumdrum(Toolkit *tk);
 const char *vrvToolkit_getLog(Toolkit *tk);
@@ -75,6 +76,12 @@ const char *vrvToolkit_getAvailableOptions(Toolkit *tk)
 const char *vrvToolkit_getElementAttr(Toolkit *tk, const char *xmlId)
 {
     tk->SetCString(tk->GetElementAttr(xmlId));
+    return tk->GetCString();
+}
+
+const char *vrvToolkit_getElementChildPitches(Toolkit *tk, const char *xmlId)
+{
+    tk->SetCString(tk->GetElementChildrenPitches(xmlId));
     return tk->GetCString();
 }
 

--- a/emscripten/emscripten_main.cpp
+++ b/emscripten/emscripten_main.cpp
@@ -26,6 +26,7 @@ const char *vrvToolkit_getAvailableOptions(Toolkit *tk);
 const char *vrvToolkit_getElementAttr(Toolkit *tk, const char *xmlId);
 const char *vrvToolkit_getElementChildPitches(Toolkit *tk, const char *xmlId);
 const char *vrvToolkit_getElementsAtTime(Toolkit *tk, int millisec);
+const char *vrvToolkit_getElementStaffDef(Toolkit *tk, const char *xmlId);
 const char *vrvToolkit_getHumdrum(Toolkit *tk);
 const char *vrvToolkit_getLog(Toolkit *tk);
 const char *vrvToolkit_getMEI(Toolkit *tk, int page_no, bool score_based);
@@ -88,6 +89,12 @@ const char *vrvToolkit_getElementChildPitches(Toolkit *tk, const char *xmlId)
 const char *vrvToolkit_getElementsAtTime(Toolkit *tk, int millisec)
 {
     tk->SetCString(tk->GetElementsAtTime(millisec));
+    return tk->GetCString();
+}
+
+const char *vrvToolkit_getElementStaffDef(Toolkit *tk, const char *xmlId)
+{
+    tk->SetCString(tk->GetElementStaffDef(xmlId));
     return tk->GetCString();
 }
 

--- a/emscripten/verovio-proxy.js
+++ b/emscripten/verovio-proxy.js
@@ -24,6 +24,9 @@ verovio.vrvToolkit.getElementChildPitches = Module.cwrap('vrvToolkit_getElementC
 // char *getElementsAtTime(Toolkit *ic, int time)
 verovio.vrvToolkit.getElementsAtTime = Module.cwrap('vrvToolkit_getElementsAtTime', 'string', ['number', 'number']);
 
+// char *getElementStaffDef(Toolkit *ic, const char *xmlId)
+verovio.vrvToolkit.getElementStaffDef = Module.cwrap('vrvToolkit_getElementStaffDef', 'string', ['number', 'string']);
+
 // char *getHumdrum(Toolkit *ic)
 verovio.vrvToolkit.getHumdrum = Module.cwrap('vrvToolkit_getHumdrum', 'string');
 
@@ -107,6 +110,10 @@ verovio.toolkit.prototype.getElementChildPitches = function (xmlId) {
 
 verovio.toolkit.prototype.getElementsAtTime = function (millisec) {
 	return JSON.parse(verovio.vrvToolkit.getElementsAtTime(this.ptr, millisec));
+};
+
+verovio.toolkit.prototype.getElementStaffDef = function (xmlId) {
+        return JSON.parse(verovio.vrvToolkit.getElementStaffDef(this.ptr, xmlId));
 };
 
 verovio.toolkit.prototype.getHumdrum = function () {

--- a/emscripten/verovio-proxy.js
+++ b/emscripten/verovio-proxy.js
@@ -18,6 +18,9 @@ verovio.vrvToolkit.getAvailableOptions = Module.cwrap('vrvToolkit_getAvailableOp
 // char *getElementAttr(Toolkit *ic, const char *xmlId)
 verovio.vrvToolkit.getElementAttr = Module.cwrap('vrvToolkit_getElementAttr', 'string', ['number', 'string']);
 
+// char *getElementChildPitches(Toolkit *ic, const char *xmlId)
+verovio.vrvToolkit.getElementChildPitches = Module.cwrap('vrvToolkit_getElementChildPitches', 'string', ['number', 'string']);
+
 // char *getElementsAtTime(Toolkit *ic, int time)
 verovio.vrvToolkit.getElementsAtTime = Module.cwrap('vrvToolkit_getElementsAtTime', 'string', ['number', 'number']);
 
@@ -96,6 +99,10 @@ verovio.toolkit.prototype.getAvailableOptions = function () {
 
 verovio.toolkit.prototype.getElementAttr = function (xmlId) {
 	return JSON.parse(verovio.vrvToolkit.getElementAttr(this.ptr, xmlId));
+};
+
+verovio.toolkit.prototype.getElementChildPitches = function (xmlId) {
+        return JSON.parse(verovio.vrvToolkit.getElementChildPitches(this.ptr, xmlId));
 };
 
 verovio.toolkit.prototype.getElementsAtTime = function (millisec) {

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -168,6 +168,11 @@ public:
     std::string GetElementAttr(const std::string &xmlId);
 
     /**
+     * Return element children as JSON string
+     */
+    std::string GetElementChildrenPitches(const std::string &xmlId);
+
+    /**
      * Redo the layout of the loaded data.
      * This can be called once the rendering option were changed,
      * For example with a new page (sceen) height or a new zoom level.

--- a/include/vrv/toolkit.h
+++ b/include/vrv/toolkit.h
@@ -172,6 +172,13 @@ public:
      */
     std::string GetElementChildrenPitches(const std::string &xmlId);
 
+
+    /**
+     * Return selected StaffDef attributes for the given element
+     * If the element cannot be found, return an empty JSON string
+     */
+    std::string GetElementStaffDef(const std::string &xmlId);
+
     /**
      * Redo the layout of the loaded data.
      * This can be called once the rendering option were changed,

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -883,6 +883,37 @@ std::string Toolkit::GetElementAttr(const std::string &xmlId)
     return o.json();
 }
 
+std::string Toolkit::GetElementChildrenPitches(const std::string &xmlId)
+{
+    jsonxx::Object o;
+
+    if(!m_doc.GetDrawingPage()) return o.json();
+    Object *parent = m_doc.GetDrawingPage()->FindChildByUuid(xmlId);
+    if (!parent) {
+        LogMessage("Element with id '%s' could not be found", xmlId.c_str());
+        return o.json();
+    }
+
+    // Get array of children 
+    ArrayOfObjects children;
+    InterfaceComparison comparison(INTERFACE_PITCH);
+    parent->FindAllChildByComparison(&children, &comparison);
+   
+    int i = 1; 
+    for (auto iter = children.begin(); iter != children.end(); ++iter) {
+        Object *child = dynamic_cast<Object *>(*iter);
+        if (child == nullptr) continue;
+        PitchInterface *pi = child->GetPitchInterface();
+        assert(pi);
+        jsonxx::Object pitch;
+        pitch << "pname" << std::to_string(pi->GetPname());
+        pitch << "oct" << std::to_string(pi->GetOct());
+        o << std::to_string(i++) << pitch;
+    }
+
+    return o.json();
+}
+
 bool Toolkit::Edit(const std::string &json_editorAction)
 {
 #ifdef USE_EMSCRIPTEN

--- a/src/toolkit.cpp
+++ b/src/toolkit.cpp
@@ -30,6 +30,7 @@
 #include "page.h"
 #include "slur.h"
 #include "staff.h"
+#include "staffdef.h"
 #include "svgdevicecontext.h"
 #include "vrv.h"
 
@@ -911,6 +912,36 @@ std::string Toolkit::GetElementChildrenPitches(const std::string &xmlId)
         o << std::to_string(i++) << pitch;
     }
 
+    return o.json();
+}
+
+std::string Toolkit::GetElementStaffDef(const std::string &xmlId)
+{
+    jsonxx::Object o;
+
+    if (!m_doc.GetDrawingPage()) return o.json();
+    Object *element = m_doc.GetDrawingPage()->FindChildByUuid(xmlId);
+    if (!element) {
+        LogMessage("Element with id '%s' could not be found", xmlId.c_str());
+        return o.json();
+    }
+
+    Staff *staff = dynamic_cast<Staff *>(
+        element->GetClassId() == STAFF ? element : element->GetFirstParent(STAFF)
+    );
+    if (staff == nullptr) {
+        LogMessage("Could not find an associated staff for element with id '%s'", xmlId.c_str());
+        return o.json();
+    }
+
+    StaffDef *staffDef = staff->m_drawingStaffDef;
+
+    ArrayOfStrAttr attributes;
+    staffDef->GetAttributes(&attributes);
+
+    for (auto iter = attributes.begin(); iter != attributes.end(); ++iter) {
+        o << (*iter).first << (*iter).second;
+    }
     return o.json();
 }
 


### PR DESCRIPTION
Replaces larger `vrv::Toolkit::Query` function but also adds `GetElementChildPitches` and `GetElementStaffDef` to toolkit. I don't think either of these can be easily replicated with preexisting functions in verovio.

We need to get the children for neumes from within verovio since the rendered glyphs categorized as NCs are **not** the actual components for some groupings (ex porrectus).

Clef information is stored in the StaffDef along with plenty of other info, so `GetElementStaffDef` should be useful in other contexts.

@lpugin do you have any comments?